### PR TITLE
Custom width and height

### DIFF
--- a/CineIOExampleApp/src/main/java/io/cine/example/CineIoStreamViewActivity.java
+++ b/CineIOExampleApp/src/main/java/io/cine/example/CineIoStreamViewActivity.java
@@ -16,6 +16,7 @@ import org.json.JSONObject;
 import io.cine.android.CineIoClient;
 import io.cine.android.CineIoConfig;
 import io.cine.android.api.Stream;
+import io.cine.android.streaming.EncodingConfig;
 
 public class CineIoStreamViewActivity extends Activity {
 
@@ -60,7 +61,11 @@ public class CineIoStreamViewActivity extends Activity {
             @Override
             public void onClick(View view) {
                 Log.d(TAG, "Starting broadcast for " + stream.getId());
-                mClient.broadcast(stream.getId(), me);
+                EncodingConfig config = new EncodingConfig();
+                //TO SET A CUSTOM WIDTH AND HEIGHT
+                //config.setWidth(640);
+                //config.setHeight(480);
+                mClient.broadcast(stream.getId(), config, me);
             }
         });
 

--- a/CineIOExampleApp/src/main/java/io/cine/example/CineIoStreamViewActivity.java
+++ b/CineIOExampleApp/src/main/java/io/cine/example/CineIoStreamViewActivity.java
@@ -13,10 +13,10 @@ import android.widget.TextView;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import io.cine.android.BroadcastConfig;
 import io.cine.android.CineIoClient;
 import io.cine.android.CineIoConfig;
 import io.cine.android.api.Stream;
-import io.cine.android.streaming.EncodingConfig;
 
 public class CineIoStreamViewActivity extends Activity {
 
@@ -61,7 +61,7 @@ public class CineIoStreamViewActivity extends Activity {
             @Override
             public void onClick(View view) {
                 Log.d(TAG, "Starting broadcast for " + stream.getId());
-                EncodingConfig config = new EncodingConfig();
+                BroadcastConfig config = new BroadcastConfig();
                 //TO SET A CUSTOM WIDTH AND HEIGHT
                 //config.setWidth(640);
                 //config.setHeight(480);

--- a/CineIOExampleApp/src/main/java/io/cine/example/CineIoStreamViewActivity.java
+++ b/CineIOExampleApp/src/main/java/io/cine/example/CineIoStreamViewActivity.java
@@ -67,6 +67,8 @@ public class CineIoStreamViewActivity extends Activity {
                 //config.setHeight(480);
                 //TO LOCK AN ORIENTATION
                 //config.lockOrientation("landscape");
+                //TO SELECT A CAMERA
+                //config.selectCamera("back");
                 mClient.broadcast(stream.getId(), config, me);
             }
         });

--- a/CineIOExampleApp/src/main/java/io/cine/example/CineIoStreamViewActivity.java
+++ b/CineIOExampleApp/src/main/java/io/cine/example/CineIoStreamViewActivity.java
@@ -65,6 +65,8 @@ public class CineIoStreamViewActivity extends Activity {
                 //TO SET A CUSTOM WIDTH AND HEIGHT
                 //config.setWidth(640);
                 //config.setHeight(480);
+                //TO LOCK AN ORIENTATION
+                //config.lockOrientation("landscape");
                 mClient.broadcast(stream.getId(), config, me);
             }
         });

--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ client.broadcast(streamId, this);
 // `this` is a Context, such as your instance of an Activity.
 ```
 
+```java
+// To use a custom width and height
+import io.cine.android.streaming.EncodingConfig;
+
+String streamId = "STREAM_ID";
+EncodingConfig config = new EncodingConfig();
+config.setWidth(640);
+config.setHeight(480);
+client.broadcast(streamId, config, this);
+// `this` is a Context, such as your instance of an Activity.
+```
+
 ### Play
 
 Playing a live stream will launch the default Video Player a user has configured, or ask the user which application to launch for playing a live video.

--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ client.broadcast(streamId, this);
 
 ```java
 // To use a custom width, height, and orientation
-import io.cine.android.streaming.EncodingConfig;
+import io.cine.android.BroadcastConfig;
 
 String streamId = "STREAM_ID";
-EncodingConfig config = new EncodingConfig();
+BroadcastConfig config = new BroadcastConfig();
 config.setWidth(640);
 config.setHeight(480);
 config.lockOrientation("landscape"); //values are "landscape" and "portrait". Not setting the value will allow the view to switch depending on device orientation

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ EncodingConfig config = new EncodingConfig();
 config.setWidth(640);
 config.setHeight(480);
 config.lockOrientation("landscape"); //values are "landscape" and "portrait". Not setting the value will allow the view to switch depending on device orientation
+config.selectCamera("back"); //values are "back" and "front". Not setting the value will default to front facing
 client.broadcast(streamId, config, this);
 // `this` is a Context, such as your instance of an Activity.
 ```

--- a/README.md
+++ b/README.md
@@ -88,13 +88,14 @@ client.broadcast(streamId, this);
 ```
 
 ```java
-// To use a custom width and height
+// To use a custom width, height, and orientation
 import io.cine.android.streaming.EncodingConfig;
 
 String streamId = "STREAM_ID";
 EncodingConfig config = new EncodingConfig();
 config.setWidth(640);
 config.setHeight(480);
+config.lockOrientation("landscape"); //values are "landscape" and "portrait". Not setting the value will allow the view to switch depending on device orientation
 client.broadcast(streamId, config, this);
 // `this` is a Context, such as your instance of an Activity.
 ```

--- a/cineio-broadcast-android-sdk/src/main/java/io/cine/android/BroadcastActivity.java
+++ b/cineio-broadcast-android-sdk/src/main/java/io/cine/android/BroadcastActivity.java
@@ -155,12 +155,21 @@ public class BroadcastActivity extends Activity
         String outputString;
         int width = -1;
         int height = -1;
+        String orientation = null;
         if (extras != null) {
             outputString = extras.getString("PUBLISH_URL");
             width = extras.getInt("WIDTH", -1);
             height = extras.getInt("HEIGHT", -1);
+            orientation = extras.getString("ORIENTATION");
         }else{
             outputString = Environment.getExternalStorageDirectory().getAbsolutePath() + "/cineio-recording.mp4";
+        }
+
+        if(orientation.equals("landscape")){
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+        }
+        if(orientation.equals("portrait")){
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         }
 
         mEncodingConfig = new EncodingConfig(this);

--- a/cineio-broadcast-android-sdk/src/main/java/io/cine/android/BroadcastActivity.java
+++ b/cineio-broadcast-android-sdk/src/main/java/io/cine/android/BroadcastActivity.java
@@ -142,6 +142,7 @@ public class BroadcastActivity extends Activity
     private Camera.CameraInfo mCameraInfo;
     private AspectFrameLayout mFrameLayout;
     private EncodingConfig mEncodingConfig;
+    private String requestedCamera;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -156,19 +157,21 @@ public class BroadcastActivity extends Activity
         int width = -1;
         int height = -1;
         String orientation = null;
+
         if (extras != null) {
             outputString = extras.getString("PUBLISH_URL");
             width = extras.getInt("WIDTH", -1);
             height = extras.getInt("HEIGHT", -1);
             orientation = extras.getString("ORIENTATION");
+            this.requestedCamera = extras.getString("CAMERA");
         }else{
             outputString = Environment.getExternalStorageDirectory().getAbsolutePath() + "/cineio-recording.mp4";
         }
 
-        if(orientation.equals("landscape")){
+        if(orientation != null && orientation.equals("landscape")){
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
         }
-        if(orientation.equals("portrait")){
+        if(orientation != null && orientation.equals("portrait")){
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         }
 
@@ -283,9 +286,15 @@ public class BroadcastActivity extends Activity
 
         // Try to find a front-facing camera (e.g. for videoconferencing).
         int numCameras = Camera.getNumberOfCameras();
+        int cameraToFind;
+        if(requestedCamera != null && requestedCamera.equals("back")){
+            cameraToFind = Camera.CameraInfo.CAMERA_FACING_BACK;
+        }else{
+            cameraToFind = Camera.CameraInfo.CAMERA_FACING_FRONT;
+        }
         for (int i = 0; i < numCameras; i++) {
             Camera.getCameraInfo(i, info);
-            if (info.facing == Camera.CameraInfo.CAMERA_FACING_FRONT) {
+            if (info.facing == cameraToFind) {
                 mCameraInfo = info;
                 mCamera = Camera.open(i);
                 break;

--- a/cineio-broadcast-android-sdk/src/main/java/io/cine/android/BroadcastActivity.java
+++ b/cineio-broadcast-android-sdk/src/main/java/io/cine/android/BroadcastActivity.java
@@ -153,13 +153,25 @@ public class BroadcastActivity extends Activity
 
         Bundle extras = getIntent().getExtras();
         String outputString;
+        int width = -1;
+        int height = -1;
         if (extras != null) {
             outputString = extras.getString("PUBLISH_URL");
+            width = extras.getInt("WIDTH", -1);
+            height = extras.getInt("HEIGHT", -1);
         }else{
             outputString = Environment.getExternalStorageDirectory().getAbsolutePath() + "/cineio-recording.mp4";
         }
 
         mEncodingConfig = new EncodingConfig(this);
+        if(width != -1){
+            Log.v(TAG, "SETTING WIDTH TO: " + width);
+            mEncodingConfig.setWidth(width);
+        }
+        if(height != -1){
+            Log.v(TAG, "SETTING HEIGHT TO: " + height);
+            mEncodingConfig.setHeight(height);
+        }
         mEncodingConfig.setOutput(outputString);
         mMuxer = new FFmpegMuxer();
 

--- a/cineio-broadcast-android-sdk/src/main/java/io/cine/android/BroadcastConfig.java
+++ b/cineio-broadcast-android-sdk/src/main/java/io/cine/android/BroadcastConfig.java
@@ -1,0 +1,51 @@
+package io.cine.android;
+
+/**
+ * Created by thomas on 1/16/15.
+ */
+public class BroadcastConfig {
+    private int width;
+    private int height;
+    private String requestedCamera;
+    private String lockedOrientation;
+
+    public int getWidth() {
+        return width;
+    }
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public void setHeight(int height) {
+        this.height = height;
+    }
+
+    public String getLockedOrientation() {
+        return lockedOrientation;
+    }
+
+    public void lockOrientation(String lockedOrientation) {
+        if(lockedOrientation.equals("landscape") || lockedOrientation.equals("portrait") || lockedOrientation == null){
+            this.lockedOrientation = lockedOrientation;
+        } else {
+            throw new RuntimeException("Orientation must be \"landscape\" or \"portrait\"");
+        }
+    }
+
+    public String getRequestedCamera() {
+        return requestedCamera;
+    }
+
+    public void selectCamera(String camera) {
+        if(camera.equals("back") || camera.equals("front") || camera == null){
+            this.requestedCamera = camera;
+        } else {
+            throw new RuntimeException("Camera must be \"front\" or \"back\"");
+        }
+    }
+}

--- a/cineio-broadcast-android-sdk/src/main/java/io/cine/android/CineIoClient.java
+++ b/cineio-broadcast-android-sdk/src/main/java/io/cine/android/CineIoClient.java
@@ -70,6 +70,9 @@ public class CineIoClient {
                 intent.putExtra("PUBLISH_URL", stream.getPublishUrl());
                 intent.putExtra("WIDTH", config.getLandscapeWidth());
                 intent.putExtra("HEIGHT", config.getLandscapeHeight());
+                if(config.getLockedOrientation() != null){
+                    intent.putExtra("ORIENTATION", config.getLockedOrientation());
+                }
 //                intent.putExtra("SELECTED_CAMERA", selectedCamera);
 //                intent.putExtra("LOCK_SCREEN", lockScreen);
 

--- a/cineio-broadcast-android-sdk/src/main/java/io/cine/android/CineIoClient.java
+++ b/cineio-broadcast-android-sdk/src/main/java/io/cine/android/CineIoClient.java
@@ -26,6 +26,7 @@ import io.cine.android.api.StreamRecordingResponseHandler;
 import io.cine.android.api.StreamRecordingsResponseHandler;
 import io.cine.android.api.StreamResponseHandler;
 import io.cine.android.api.StreamsResponseHandler;
+import io.cine.android.streaming.EncodingConfig;
 
 public class CineIoClient {
 
@@ -45,6 +46,7 @@ public class CineIoClient {
         return mConfig.getSecretKey();
     }
 
+    // Use default config
     public void broadcast(String id, final Context context){
         final Intent intent = new Intent(context, BroadcastActivity.class);
 
@@ -52,6 +54,25 @@ public class CineIoClient {
             public void onSuccess(Stream stream) {
                 Log.d(TAG, "Starting publish intent: " + stream.getId());
                 intent.putExtra("PUBLISH_URL", stream.getPublishUrl());
+                context.startActivity(intent);
+            }
+
+        });
+    }
+
+    //pass in custom values
+    public void broadcast(String id, final EncodingConfig config,  final Context context){
+        final Intent intent = new Intent(context, BroadcastActivity.class);
+
+        getStream(id, new StreamResponseHandler(){
+            public void onSuccess(Stream stream) {
+                Log.d(TAG, "Starting publish intent: " + stream.getId());
+                intent.putExtra("PUBLISH_URL", stream.getPublishUrl());
+                intent.putExtra("WIDTH", config.getLandscapeWidth());
+                intent.putExtra("HEIGHT", config.getLandscapeHeight());
+//                intent.putExtra("SELECTED_CAMERA", selectedCamera);
+//                intent.putExtra("LOCK_SCREEN", lockScreen);
+
                 context.startActivity(intent);
             }
 

--- a/cineio-broadcast-android-sdk/src/main/java/io/cine/android/CineIoClient.java
+++ b/cineio-broadcast-android-sdk/src/main/java/io/cine/android/CineIoClient.java
@@ -26,7 +26,6 @@ import io.cine.android.api.StreamRecordingResponseHandler;
 import io.cine.android.api.StreamRecordingsResponseHandler;
 import io.cine.android.api.StreamResponseHandler;
 import io.cine.android.api.StreamsResponseHandler;
-import io.cine.android.streaming.EncodingConfig;
 
 public class CineIoClient {
 
@@ -61,24 +60,21 @@ public class CineIoClient {
     }
 
     //pass in custom values
-    public void broadcast(String id, final EncodingConfig config,  final Context context){
+    public void broadcast(String id, final BroadcastConfig config,  final Context context){
         final Intent intent = new Intent(context, BroadcastActivity.class);
 
         getStream(id, new StreamResponseHandler(){
             public void onSuccess(Stream stream) {
                 Log.d(TAG, "Starting publish intent: " + stream.getId());
                 intent.putExtra("PUBLISH_URL", stream.getPublishUrl());
-                intent.putExtra("WIDTH", config.getLandscapeWidth());
-                intent.putExtra("HEIGHT", config.getLandscapeHeight());
+                intent.putExtra("WIDTH", config.getWidth());
+                intent.putExtra("HEIGHT", config.getHeight());
                 if(config.getLockedOrientation() != null){
                     intent.putExtra("ORIENTATION", config.getLockedOrientation());
                 }
                 if(config.getRequestedCamera() != null){
                     intent.putExtra("CAMERA", config.getRequestedCamera());
                 }
-//                intent.putExtra("SELECTED_CAMERA", selectedCamera);
-//                intent.putExtra("LOCK_SCREEN", lockScreen);
-
                 context.startActivity(intent);
             }
 

--- a/cineio-broadcast-android-sdk/src/main/java/io/cine/android/CineIoClient.java
+++ b/cineio-broadcast-android-sdk/src/main/java/io/cine/android/CineIoClient.java
@@ -73,6 +73,9 @@ public class CineIoClient {
                 if(config.getLockedOrientation() != null){
                     intent.putExtra("ORIENTATION", config.getLockedOrientation());
                 }
+                if(config.getRequestedCamera() != null){
+                    intent.putExtra("CAMERA", config.getRequestedCamera());
+                }
 //                intent.putExtra("SELECTED_CAMERA", selectedCamera);
 //                intent.putExtra("LOCK_SCREEN", lockScreen);
 

--- a/cineio-broadcast-android-sdk/src/main/java/io/cine/android/streaming/EncodingConfig.java
+++ b/cineio-broadcast-android-sdk/src/main/java/io/cine/android/streaming/EncodingConfig.java
@@ -11,6 +11,7 @@ import io.cine.ffmpegbridge.FFmpegBridge;
 public class EncodingConfig {
 
     private String lockedOrientation;
+    private String camera;
 
     public interface EncodingCallback {
         public void muxerStatusUpdate(MUXER_STATE muxerState);
@@ -99,6 +100,18 @@ public class EncodingConfig {
 
     public String getLockedOrientation() {
         return lockedOrientation;
+    }
+
+    public void selectCamera(String camera) {
+        if(camera.equals("back") || camera.equals("front") || camera == null){
+            this.camera = camera;
+        } else {
+            throw new RuntimeException("Camera must be \"front\" or \"back\"");
+        }
+    }
+
+    public String getRequestedCamera() {
+        return camera;
     }
 
     public int getBitrate() {

--- a/cineio-broadcast-android-sdk/src/main/java/io/cine/android/streaming/EncodingConfig.java
+++ b/cineio-broadcast-android-sdk/src/main/java/io/cine/android/streaming/EncodingConfig.java
@@ -90,30 +90,6 @@ public class EncodingConfig {
         return this.customHeight == -1 ? LANDSCAPE_CAMERA_HEIGHT : this.customHeight;
     }
 
-    public void lockOrientation(String lockedOrientation) {
-        if(lockedOrientation.equals("landscape") || lockedOrientation.equals("portrait") || lockedOrientation == null){
-            this.lockedOrientation = lockedOrientation;
-        } else {
-            throw new RuntimeException("Orientation must be \"landscape\" or \"portrait\"");
-        }
-    }
-
-    public String getLockedOrientation() {
-        return lockedOrientation;
-    }
-
-    public void selectCamera(String camera) {
-        if(camera.equals("back") || camera.equals("front") || camera == null){
-            this.camera = camera;
-        } else {
-            throw new RuntimeException("Camera must be \"front\" or \"back\"");
-        }
-    }
-
-    public String getRequestedCamera() {
-        return camera;
-    }
-
     public int getBitrate() {
         return DEFAULT_BIT_RATE;
     }

--- a/cineio-broadcast-android-sdk/src/main/java/io/cine/android/streaming/EncodingConfig.java
+++ b/cineio-broadcast-android-sdk/src/main/java/io/cine/android/streaming/EncodingConfig.java
@@ -10,6 +10,8 @@ import io.cine.ffmpegbridge.FFmpegBridge;
  */
 public class EncodingConfig {
 
+    private String lockedOrientation;
+
     public interface EncodingCallback {
         public void muxerStatusUpdate(MUXER_STATE muxerState);
     }
@@ -85,6 +87,18 @@ public class EncodingConfig {
 
     private int getOrientationAgnosticHeight(){
         return this.customHeight == -1 ? LANDSCAPE_CAMERA_HEIGHT : this.customHeight;
+    }
+
+    public void lockOrientation(String lockedOrientation) {
+        if(lockedOrientation.equals("landscape") || lockedOrientation.equals("portrait") || lockedOrientation == null){
+            this.lockedOrientation = lockedOrientation;
+        } else {
+            throw new RuntimeException("Orientation must be \"landscape\" or \"portrait\"");
+        }
+    }
+
+    public String getLockedOrientation() {
+        return lockedOrientation;
     }
 
     public int getBitrate() {

--- a/cineio-broadcast-android-sdk/src/main/java/io/cine/android/streaming/EncodingConfig.java
+++ b/cineio-broadcast-android-sdk/src/main/java/io/cine/android/streaming/EncodingConfig.java
@@ -9,16 +9,19 @@ import io.cine.ffmpegbridge.FFmpegBridge;
  * Created by thomas on 7/1/14.
  */
 public class EncodingConfig {
+
     public interface EncodingCallback {
         public void muxerStatusUpdate(MUXER_STATE muxerState);
     }
     private static final String TAG = "EncodingConfig";
 
+    private int customWidth;
     private static final int LANDSCAPE_CAMERA_WIDTH = 1280;
+    private int customHeight;
     private static final int LANDSCAPE_CAMERA_HEIGHT = 720;
     private static int DEFAULT_BIT_RATE = 1500000;
     private static int DEFAULT_HUMAN_FPS = 15;
-    private final EncodingCallback mEncodingCallback;
+    private EncodingCallback mEncodingCallback;
     private MUXER_STATE mMuxerState;
 
     public static enum MUXER_STATE {PREPARING, READY, CONNECTING, STREAMING, SHUTDOWN}
@@ -33,30 +36,55 @@ public class EncodingConfig {
         mEncodingCallback = encodingCallback;
         mOrientation = Surface.ROTATION_0;
         mMachineVideoFps = DEFAULT_HUMAN_FPS * 1000;
+        setDefaultValues();
+    }
+
+    public EncodingConfig(){
+        setDefaultValues();
+    }
+    private void setDefaultValues(){
+        this.customHeight = -1;
+        this.customWidth = -1;
+    }
+
+    public void setWidth(int width){
+        this.customWidth = width;
+    }
+
+    public void setHeight(int height){
+        this.customHeight = height;
     }
 
     public int getWidth() {
         if (isLandscape()) {
-            return LANDSCAPE_CAMERA_WIDTH;
+            return getOrientationAgnosticWidth();
         } else {
-            return LANDSCAPE_CAMERA_HEIGHT;
+            return getOrientationAgnosticHeight();
         }
     }
 
     public int getHeight() {
         if (isLandscape()) {
-            return LANDSCAPE_CAMERA_HEIGHT;
+            return getOrientationAgnosticHeight();
         } else {
-            return LANDSCAPE_CAMERA_WIDTH;
+            return getOrientationAgnosticWidth();
         }
     }
 
     public int getLandscapeWidth() {
-        return LANDSCAPE_CAMERA_WIDTH;
+        return getOrientationAgnosticWidth();
     }
 
     public int getLandscapeHeight() {
-        return LANDSCAPE_CAMERA_HEIGHT;
+        return getOrientationAgnosticHeight();
+    }
+
+    private int getOrientationAgnosticWidth(){
+        return this.customWidth == -1 ? LANDSCAPE_CAMERA_WIDTH : this.customWidth;
+    }
+
+    private int getOrientationAgnosticHeight(){
+        return this.customHeight == -1 ? LANDSCAPE_CAMERA_HEIGHT : this.customHeight;
     }
 
     public int getBitrate() {


### PR DESCRIPTION
@lgorse what do you think about this PR for custom width and heights. Due to the camera requirements, the width and height must be landscape values, but it can translate to portrait. Meaning the camera can only open in 640x480 and not 480x640. But when the camera is rotated to portrait, it acts as 480x640, if that makes sense.