### PR TITLE
Resolution

### DIFF
--- a/cineio-broadcast-android-sdk/build.gradle
+++ b/cineio-broadcast-android-sdk/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 19
     buildToolsVersion '19.1.0'
     defaultConfig {
-        applicationId 'io.cine.android'
+        //applicationId 'io.cine.android'
         minSdkVersion 18
         targetSdkVersion 19
         versionCode 10
@@ -12,7 +12,7 @@ android {
     }
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
@@ -29,4 +29,4 @@ dependencies {
 
 //apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'
 //apply from: 'https://raw.githubusercontent.com/jpardogo/gradle-mvn-push/master/gradle-mvn-push.gradle'
-apply from: 'https://raw.githubusercontent.com/cine-io/gradle-mvn-push/master/gradle-mvn-push.gradle'
+//apply from: 'https://raw.githubusercontent.com/cine-io/gradle-mvn-push/master/gradle-mvn-push.gradle'

--- a/cineio-broadcast-android-sdk/cineio-broadcast-android-sdk.iml
+++ b/cineio-broadcast-android-sdk/cineio-broadcast-android-sdk.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="cineio-broadcast-android" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="cineio-broadcast-android" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
@@ -10,9 +10,10 @@
       <configuration>
         <option name="SELECTED_BUILD_VARIANT" value="debug" />
         <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
-        <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugJava" />
+        <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
         <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugTest" />
         <option name="SOURCE_GEN_TASK_NAME" value="generateDebugSources" />
+        <option name="TEST_SOURCE_GEN_TASK_NAME" value="generateDebugTestSources" />
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
         <option name="RES_FOLDER_RELATIVE_PATH" value="/src/main/res" />
@@ -31,29 +32,31 @@
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/debug" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/generated/debug" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/test/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/test/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/test/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/test/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/test/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/generated/test/debug" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/aidl" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/assets" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/aidl" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/main/assets" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
@@ -76,9 +79,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
-      <excludeFolder url="file://$MODULE_DIR$/build/libs" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/poms" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 19 Platform" jdkType="Android SDK" />

--- a/cineio-broadcast-android-sdk/src/main/java/io/cine/android/BroadcastConfig.java
+++ b/cineio-broadcast-android-sdk/src/main/java/io/cine/android/BroadcastConfig.java
@@ -1,5 +1,7 @@
 package io.cine.android;
 
+import android.util.Log;
+
 /**
  * Created by thomas on 1/16/15.
  */
@@ -8,6 +10,7 @@ public class BroadcastConfig {
     private int height;
     private String requestedCamera;
     private String lockedOrientation;
+
 
     public int getWidth() {
         return width;

--- a/cineio-broadcast-android-sdk/src/main/java/io/cine/android/BroadcastConfig.java
+++ b/cineio-broadcast-android-sdk/src/main/java/io/cine/android/BroadcastConfig.java
@@ -6,14 +6,18 @@ import android.util.Log;
  * Created by thomas on 1/16/15.
  */
 public class BroadcastConfig {
-    private int width;
-    private int height;
+    private Integer width;
+    private Integer height;
     private String requestedCamera;
     private String lockedOrientation;
 
 
     public int getWidth() {
-        return width;
+        if (width == null){
+            return -1;
+        }else{
+            return width;
+        }
     }
 
     public void setWidth(int width) {
@@ -21,7 +25,11 @@ public class BroadcastConfig {
     }
 
     public int getHeight() {
-        return height;
+        if (height == null){
+            return -1;
+        }else{
+            return height;
+        }
     }
 
     public void setHeight(int height) {

--- a/cineio-broadcast-android-sdk/src/main/java/io/cine/android/CineIoClient.java
+++ b/cineio-broadcast-android-sdk/src/main/java/io/cine/android/CineIoClient.java
@@ -35,6 +35,8 @@ public class CineIoClient {
     private final AsyncHttpClient mClient;
     private CineIoConfig mConfig;
 
+
+
     public CineIoClient(CineIoConfig config){
         this.mConfig = config;
         this.mClient = new AsyncHttpClient();


### PR DESCRIPTION
This is a proposed resolution for:
https://github.com/cine-io/cineio-broadcast-android/issues/5

The ints in BroadcastConfig are set to Integers so they can be null, satisfying the checks that are set up in BroadcastActivity to ensure that a default resolution is captured.

Sorry a commit correcting build.gradle is sneaking up in there - I have yet to figure out how to ignore build.gradle in the android-sdk subdirectory.